### PR TITLE
  Missing Encoding for Non-ASCII Compatibility 

### DIFF
--- a/generate_sample_data.py
+++ b/generate_sample_data.py
@@ -42,7 +42,8 @@ def create_sample_data():
     # Create and write to CSV files
     for filename, rows in data.items():
         filepath = os.path.join(data_dir, filename)
-        with open(filepath, 'w', newline='') as f:
+        # with encoding, Supports all characters
+        with open(filepath, 'w', newline='', encoding='utf-8') as f:
             writer = csv.writer(f)
             writer.writerows(rows)
         print(f"Generated {filename}")


### PR DESCRIPTION
issue: If you include non-English names or symbols in future data, the default encoding may break on Windows.
  ->What Happens Without Encoding?
  Suppose your data includes a string like:
   text: Émilie Dubois
  If you run this script on Windows without encoding:

        after run-> You might get a UnicodeEncodeError:
      like this UnicodeEncodeError: 'charmap' codec can't encode character '\u00c9' in position 0: character maps to <undefined>
 
easy way to fix it:
Always specify encoding explicitly: using encoding = "utf-8" 

benefits: Works consistently across OS (Linux, Windows, macOS).
Prevents crashes due to UnicodeEncodeError.
Supports non-English names, accents, emojis, etc.
 
![bc038d93-27b3-4de9-87d4-d9685ca30b0a](https://github.com/user-attachments/assets/b49d29a0-fb0e-4322-9925-e57a2c724bfb)



